### PR TITLE
fixed commands call to correspond to latest CommandRegistry

### DIFF
--- a/lib/clear-storage.coffee
+++ b/lib/clear-storage.coffee
@@ -14,7 +14,8 @@ unlinkFiles = (dir) ->
 
 module.exports =
 	activate: (state) ->
-		atom.workspaceView.command "clear-storage:clear", ->
-			unlinkFiles atom.constructor.getStorageDirPath()
+		atom.commands.add 'atom-workspace',
+			'clear-storage:clear': ->
+					unlinkFiles atom.constructor.getStorageDirPath()
 
 	deactivate: ->

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "repository": "https://github.com/postcasio/clear-storage",
   "license": "MIT",
   "engines": {
-    "atom": ">0.50.0"
+    "atom": ">1.0.0"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
Hi!
Recently I updated Atom.io to latest version and got this error at startup:

**Atom Version**: 1.4.0
**System**: Ubuntu 14.04.3
**Thrown From**: [clear-storage](https://github.com/postcasio/clear-storage) package, v0.1.0
### Stack Trace

Failed to activate the clear-storage package

```
At Cannot read property 'command' of undefined

TypeError: Cannot read property 'command' of undefined
    at Object.module.exports.activate (<anonymous>:17:21)
    at Package.module.exports.Package.activateNow (/usr/share/atom/resources/app.asar/src/package.js:183:20)
    at /usr/share/atom/resources/app.asar/src/package.js:156:32
    at Package.module.exports.Package.measure (/usr/share/atom/resources/app.asar/src/package.js:92:15)
    at /usr/share/atom/resources/app.asar/src/package.js:149:26
    at Package.module.exports.Package.activate (/usr/share/atom/resources/app.asar/src/package.js:146:34)
    at PackageManager.module.exports.PackageManager.activatePackage (/usr/share/atom/resources/app.asar/src/package-manager.js:524:21)
    at /usr/share/atom/resources/app.asar/src/package-manager.js:505:29
    at Config.module.exports.Config.transactAsync (/usr/share/atom/resources/app.asar/src/config.js:337:18)
    at PackageManager.module.exports.PackageManager.activatePackages (/usr/share/atom/resources/app.asar/src/package-manager.js:500:19)
    at PackageManager.module.exports.PackageManager.activate (/usr/share/atom/resources/app.asar/src/package-manager.js:483:46)
    at AtomEnvironment.module.exports.AtomEnvironment.startEditorWindow (/usr/share/atom/resources/app.asar/src/atom-environment.js:688:21)
    at module.exports (/usr/share/atom/resources/app.asar/src/initialize-application-window.js:28:10)
    at setupWindow (file:///usr/share/atom/resources/app.asar/static/index.js:86:5)
    at window.onload (file:///usr/share/atom/resources/app.asar/static/index.js:41:9)
```

It turned out that this error began to appear when command subscription portion of API has changed: https://atom.io/docs/v1.4.0/upgrading-to-1-0-apis-upgrading-your-package#subscribing-to-commands. This pull request fixes that according to documentation, also I changed minimal atom engine in package.json.
